### PR TITLE
Resolve LOCAL_MODULE_TAGS errors

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -56,7 +56,7 @@ LOCAL_MODULE := sens
 LOCAL_CFLAGS := -DLOG_TAG=\"Sensors\" -fvisibility=hidden
 LOCAL_SHARED_LIBRARIES := liblog libcutils libdl
 LOCAL_SRC_FILES := sens.c
-LOCAL_MODULE_TAGS := eng
+LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR_EXECUTABLES)
 include $(BUILD_EXECUTABLE)
 
@@ -87,6 +87,6 @@ LOCAL_MODULE := activity
 LOCAL_CFLAGS := -DLOG_TAG=\"Activity\" -fvisibility=hidden
 LOCAL_SHARED_LIBRARIES := liblog libcutils libdl
 LOCAL_SRC_FILES := activity.c
-LOCAL_MODULE_TAGS := eng
+LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR_EXECUTABLES)
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
```
external/iio-sensors-hal/Android.mk: error: sens: LOCAL_MODULE_TAGS := eng is obsolete. See https://android.googlesource.com/platform/build/+/master/Changes.md#LOCAL_MODULE_TAGS 
```